### PR TITLE
humanlog: remove deprecated option from formula

### DIFF
--- a/humanlog.rb
+++ b/humanlog.rb
@@ -6,7 +6,6 @@ class Humanlog < Formula
   desc ""
   homepage ""
   version "0.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/aybabtme/humanlog/releases/download/0.5.0/humanlog_0.5.0_darwin_amd64.tar.gz"


### PR DESCRIPTION
Fix this warning that is shown during `brew update`:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the aybabtme/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/aybabtme/homebrew-tap/humanlog.rb:9
```