### PR TITLE
fix homebrew tap issues

### DIFF
--- a/bitflip.rb
+++ b/bitflip.rb
@@ -3,7 +3,6 @@ class Bitflip < Formula
   desc ""
   homepage ""
   version "0.2.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/aybabtme/bitflip/releases/download/v0.2.0/bitflip_0.2.0_Darwin_x86_64.tar.gz"

--- a/humanlog.rb
+++ b/humanlog.rb
@@ -6,7 +6,6 @@ class Humanlog < Formula
   desc ""
   homepage ""
   version "0.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/aybabtme/humanlog/releases/download/0.5.0/humanlog_0.5.0_darwin_amd64.tar.gz"

--- a/semaphore.rb
+++ b/semaphore.rb
@@ -6,7 +6,6 @@ class Semaphore < Formula
   desc ""
   homepage ""
   version "0.1.0"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/aybabtme/semaphore/releases/download/0.1.0/semaphore_0.1.0_darwin_amd64.tar.gz"

--- a/temple.rb
+++ b/temple.rb
@@ -3,7 +3,6 @@ class Temple < Formula
   desc ""
   homepage ""
   version "0.2.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/aybabtme/temple/releases/download/v0.2.4/temple_0.2.4_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
fixes: https://github.com/aybabtme/humanlog/issues/42

```bash
Calling bottle :unneeded is disabled! There is no replacement.
```

for 4 formulas


proof of fix

```bash
❯ brew tap troyxmccall/homebrew-humanlog-tap
==> Tapping troyxmccall/humanlog-tap
Cloning into '/usr/local/Homebrew/Library/Taps/troyxmccall/homebrew-humanlog-tap'...
remote: Enumerating objects: 119, done.
remote: Counting objects: 100% (53/53), done.
remote: Compressing objects: 100% (48/48), done.
remote: Total 119 (delta 27), reused 12 (delta 5), pack-reused 66
Receiving objects: 100% (119/119), 15.46 KiB | 833.00 KiB/s, done.
Resolving deltas: 100% (52/52), done.
Tapped 6 formulae (17 files, 26.5KB).
```

brew install

```bash
❯ brew install humanlog
==> Downloading https://github.com/aybabtme/humanlog/releases/download/0.5.0/humanlog_0.5.0_darwin_amd64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/25216233/5ca02780-7026-11eb-8810-8a80113c62d7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220421%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220421T162013Z&X-Amz-Expires=300&X-Amz-Signature=6f7713eb45f88021ec17c8da97e8a7a1947c7b74ff
######################################################################## 100.0%
==> Installing humanlog from troyxmccall/humanlog-tap
🍺  /usr/local/Cellar/humanlog/0.5.0: 5 files, 3.3MB, built in 5 seconds
==> Running `brew cleanup humanlog`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
```


```
❯ which humanlog
/usr/local/bin/humanlog
```